### PR TITLE
Implement orientation filtering and config persistence

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -8,5 +8,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveYoloTxtBatch: perImageLines => ipcRenderer.invoke('save-yolo-txt-batch', perImageLines),
   exportDataset: payload => ipcRenderer.invoke('export-dataset', payload),
   loadClasses: () => ipcRenderer.invoke('load-classes'),
-  saveClasses: classes => ipcRenderer.invoke('save-classes', classes)
+  saveClasses: classes => ipcRenderer.invoke('save-classes', classes),
+  loadConfig: () => ipcRenderer.invoke('load-config'),
+  saveConfig: cfg => ipcRenderer.invoke('save-config', cfg),
+  ensureAletas: () => ipcRenderer.invoke('ensure-aletas')
 });


### PR DESCRIPTION
## Summary
- add orientation metadata handling, config persistence, and class/orientation toggles in the renderer UI
- persist configuration and dual JSONL outputs in the main process, ensuring atomic writes and orientation-aware dataset exports
- expose new preload APIs for configuration and class maintenance

## Testing
- not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68db2387a61c83228ae90a1d3faf7af9