### PR TITLE
Disable orientation editing for non-orientable classes

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,21 @@ const ORIENTATIONS = [
 ];
 const ORIENTATION_COUNT = ORIENTATIONS.length;
 const ORIENT_DEFAULT_ID = 0;
+const NON_ORIENTATION_CLASSES = [
+  'eyes',
+  'mouth',
+  'heart',
+  'cracks',
+  'cristal',
+  'flower',
+  'zombie_zone',
+  'sky',
+  'stars',
+  'wings',
+  'claws',
+  'aletas',
+  'fangs'
+];
 
 let mainWindow;
 
@@ -498,9 +513,16 @@ ipcMain.handle('export-dataset', async (event, payload) => {
     const splits = payload.splits || { train: 0.7, val: 0.2, test: 0.1 };
     const classNames = sanitiseClasses(payload.classes || []);
     const expandOrientations = Boolean(payload.expandOrientations);
-    const classDisplayNames = expandOrientations
-      ? classNames.flatMap(className => ORIENTATIONS.map(orientation => `${className}:${orientation.key}`))
-      : classNames.slice();
+    const classDisplayNames = [];
+    classNames.forEach(className => {
+      if (expandOrientations && !NON_ORIENTATION_CLASSES.includes(className)) {
+        ORIENTATIONS.forEach(orientation => {
+          classDisplayNames.push(`${className}:${orientation.key}`);
+        });
+      } else {
+        classDisplayNames.push(className);
+      }
+    });
     const fileNames = payload.images.map(item => item.fileName);
     const shuffled = shuffle(fileNames);
 


### PR DESCRIPTION
## Summary
- prevent orientation edits for classes marked as non-orientable, keeping the selector disabled/grey and forcing the default orientation without displaying ":top" labels
- adjust YOLO export and dataset class name generation to avoid expanding orientations for non-orientable classes while preserving existing flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ff12e5588322be232f6729673bed