### PR TITLE
Add external data directory support and startup mode prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                 <div class="image-container">
                     <canvas id="imageCanvas"></canvas>
                     <div id="noImages" class="no-images">
-                        No hay imágenes en la carpeta 'toDrawMinecraft'
+                        No hay imágenes en la carpeta "Documentos/DataTextureGUI/unboxedTextures"
                     </div>
                 </div>
                 <div class="image-info">

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "build": "electron-builder"
   },
   "devDependencies": {
-    "electron": "^22.0.0"
+    "electron": "^22.0.0",
+    "electron-builder": "^26.0.12"
   },
   "dependencies": {
     "fs": "0.0.1-security",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "sweetalert2": "^11.24.0"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -1,4 +1,35 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const os = require('os');
+const path = require('path');
+
+const baseDocs = path.join(os.homedir(), 'Documents', 'DataTextureGUI');
+const exposedDirs = {
+  base: baseDocs,
+  unboxed: path.join(baseDocs, 'unboxedTextures'),
+  normal: path.join(baseDocs, 'normalTextures'),
+  labels: path.join(baseDocs, 'labels'),
+  train: path.join(baseDocs, 'trainingData'),
+  config: path.join(baseDocs, 'config')
+};
+
+const modeFiles = {
+  minecraft: {
+    jsonl: path.join(exposedDirs.train, 'trainDataMinecraft.jsonl'),
+    fullJsonl: path.join(exposedDirs.train, 'trainDataMinecraft.full.jsonl'),
+    yaml: path.join(exposedDirs.train, 'datasetMinecraft.yaml')
+  },
+  texture: {
+    jsonl: path.join(exposedDirs.train, 'trainDataNormal.jsonl'),
+    fullJsonl: path.join(exposedDirs.train, 'trainDataNormal.full.jsonl'),
+    yaml: path.join(exposedDirs.train, 'datasetNormal.yaml')
+  }
+};
+
+contextBridge.exposeInMainWorld('PIAF_PATHS', {
+  baseDocs,
+  dirs: exposedDirs,
+  modeFiles
+});
 
 contextBridge.exposeInMainWorld('electronAPI', {
   loadImages: () => ipcRenderer.invoke('load-images'),

--- a/renderer.js
+++ b/renderer.js
@@ -6,6 +6,22 @@ const SAVE_DEBOUNCE_MS = 500;
 
 const PIAF_MODE = (typeof window !== 'undefined' && window.PIAF_MODE) ? window.PIAF_MODE : 'minecraft';
 const TEXTURE_MODE = PIAF_MODE === 'texture';
+const PATH_INFO = (typeof window !== 'undefined' && window.PIAF_PATHS) ? window.PIAF_PATHS : null;
+const FALLBACK_DIRS = {
+  unboxed: 'toDrawMinecraft',
+  normal: 'toDrawNormal',
+  labels: 'labels',
+  train: ''
+};
+const DIRECTORIES = PATH_INFO ? PATH_INFO.dirs : FALLBACK_DIRS;
+const drawFolder = TEXTURE_MODE ? DIRECTORIES.normal : DIRECTORIES.unboxed;
+const modeFiles = PATH_INFO ? PATH_INFO.modeFiles : null;
+const jsonlPath = modeFiles ? (TEXTURE_MODE ? modeFiles.texture.jsonl : modeFiles.minecraft.jsonl) : '';
+const yamlPath = modeFiles ? (TEXTURE_MODE ? modeFiles.texture.yaml : modeFiles.minecraft.yaml) : '';
+const fullJsonlPath = modeFiles ? (TEXTURE_MODE ? modeFiles.texture.fullJsonl : modeFiles.minecraft.fullJsonl) : '';
+const jsonlName = jsonlPath ? jsonlPath.split(/[\\/]/).pop() : 'trainData.jsonl';
+const fullJsonlName = fullJsonlPath ? fullJsonlPath.split(/[\\/]/).pop() : 'trainData.full.jsonl';
+const yamlName = yamlPath ? yamlPath.split(/[\\/]/).pop() : 'dataset.yaml';
 
 const ORIENTATIONS = TEXTURE_MODE ? [] : [
   { id: 0, key: 'arriba', label: 'Top' },
@@ -779,6 +795,9 @@ let suppressGlobalMinecraftStyleChange = false;
 document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
+  if (noImages) {
+    noImages.textContent = `No hay imágenes en la carpeta "${drawFolder}"`;
+  }
   loadSessionPreferences();
   setupAuxiliaryContainers();
   setupConfigPanel();
@@ -1198,7 +1217,7 @@ async function ensureAletasClass() {
 async function loadExistingData() {
   const result = await window.electronAPI.loadExistingData();
   if (!result.success) {
-    showToast(`No se pudo cargar trainData.jsonl: ${result.error}`, 'error');
+    showToast(`No se pudo cargar ${jsonlName}: ${result.error}`, 'error');
     return;
   }
   const migrationStats = { migrated: 0 };
@@ -1218,7 +1237,7 @@ async function loadExistingData() {
     result.errors.forEach(error => {
       state.loadErrors.push(error);
     });
-    showToast(`Se omitieron ${result.errors.length} líneas corruptas en trainData.jsonl`, 'warning');
+    showToast(`Se omitieron ${result.errors.length} líneas corruptas en ${jsonlName}`, 'warning');
   }
 }
 

--- a/textures.html
+++ b/textures.html
@@ -52,7 +52,7 @@
                 <div class="image-container">
                     <canvas id="imageCanvas"></canvas>
                     <div id="noImages" class="no-images">
-                        No hay imágenes en la carpeta 'toDrawNormal'
+                        No hay imágenes en la carpeta "Documentos/DataTextureGUI/normalTextures"
                     </div>
                 </div>
                 <div class="image-info">


### PR DESCRIPTION
## Summary
- ensure the application prepares Documents/DataTextureGUI with mode-specific folders, sample content, and persistent configuration
- add a SweetAlert2 startup mode selector with optional "remember" support and load HTML content based on the chosen mode
- update renderer paths/UI messaging to target the external storage and expose path metadata through the preload bridge; add required dependencies for SweetAlert2 and packaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42103b6f083228ed3948aaa113ca7