### PR TITLE
Ensure Electron app uses real Documents directory for data

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,34 +1,36 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const os = require('os');
 const path = require('path');
 
-const baseDocs = path.join(os.homedir(), 'Documents', 'DataTextureGUI');
-const exposedDirs = {
-  base: baseDocs,
-  unboxed: path.join(baseDocs, 'unboxedTextures'),
-  normal: path.join(baseDocs, 'normalTextures'),
-  labels: path.join(baseDocs, 'labels'),
-  train: path.join(baseDocs, 'trainingData'),
-  config: path.join(baseDocs, 'config')
-};
+async function buildPaths() {
+  const docsPath = await ipcRenderer.invoke('get-documents-path');
+  const baseDocs = path.join(docsPath, 'DataTextureGUI');
+  const dirs = {
+    base: baseDocs,
+    unboxed: path.join(baseDocs, 'unboxedTextures'),
+    normal: path.join(baseDocs, 'normalTextures'),
+    labels: path.join(baseDocs, 'labels'),
+    train: path.join(baseDocs, 'trainingData'),
+    config: path.join(baseDocs, 'config')
+  };
 
-const modeFiles = {
-  minecraft: {
-    jsonl: path.join(exposedDirs.train, 'trainDataMinecraft.jsonl'),
-    fullJsonl: path.join(exposedDirs.train, 'trainDataMinecraft.full.jsonl'),
-    yaml: path.join(exposedDirs.train, 'datasetMinecraft.yaml')
-  },
-  texture: {
-    jsonl: path.join(exposedDirs.train, 'trainDataNormal.jsonl'),
-    fullJsonl: path.join(exposedDirs.train, 'trainDataNormal.full.jsonl'),
-    yaml: path.join(exposedDirs.train, 'datasetNormal.yaml')
-  }
-};
+  const modeFiles = {
+    minecraft: {
+      jsonl: path.join(dirs.train, 'trainDataMinecraft.jsonl'),
+      fullJsonl: path.join(dirs.train, 'trainDataMinecraft.full.jsonl'),
+      yaml: path.join(dirs.train, 'datasetMinecraft.yaml')
+    },
+    texture: {
+      jsonl: path.join(dirs.train, 'trainDataNormal.jsonl'),
+      fullJsonl: path.join(dirs.train, 'trainDataNormal.full.jsonl'),
+      yaml: path.join(dirs.train, 'datasetNormal.yaml')
+    }
+  };
 
-contextBridge.exposeInMainWorld('PIAF_PATHS', {
-  baseDocs,
-  dirs: exposedDirs,
-  modeFiles
+  contextBridge.exposeInMainWorld('PIAF_PATHS', { dirs, modeFiles });
+}
+
+buildPaths().catch(err => {
+  console.error('Failed to expose PIAF_PATHS:', err);
 });
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/renderer.js
+++ b/renderer.js
@@ -7,6 +7,10 @@ const SAVE_DEBOUNCE_MS = 500;
 const PIAF_MODE = (typeof window !== 'undefined' && window.PIAF_MODE) ? window.PIAF_MODE : 'minecraft';
 const TEXTURE_MODE = PIAF_MODE === 'texture';
 const PATH_INFO = (typeof window !== 'undefined' && window.PIAF_PATHS) ? window.PIAF_PATHS : null;
+
+if (typeof window !== 'undefined') {
+  console.log('[DEBUG] PIAF_PATHS inicializadas:', window.PIAF_PATHS);
+}
 const FALLBACK_DIRS = {
   unboxed: 'toDrawMinecraft',
   normal: 'toDrawNormal',


### PR DESCRIPTION
## Summary
- initialize data directories with `app.getPath('documents')` and migrate any legacy `Documents/DataTextureGUI` folder to the real location
- expose the real Documents path to the preload script through a secure IPC handler and inject `window.PIAF_PATHS` after each load
- update the preload bridge to derive all exported paths from the renderer-visible Documents directory and add a renderer debug log for validation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e444577f308322b4423879af7604a1